### PR TITLE
Potential fix for code scanning alert no. 22: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "google-auth-library": "^9.15.1",
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.12.0",
-    "ws": "^8.18.1"
+    "ws": "^8.18.1",
+    "lusca": "^1.7.0"
   },
   "name": "neosmentis2.0",
   "version": "1.0.0",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -1,10 +1,12 @@
 const express = require('express');
 const cookieParser = require('cookie-parser');
+const lusca = require('lusca');
 const { executeQuery } = require('../config/db');
 const { hashPassword, verifyPassword,generateToken,verificationAll,generateSecondaryKey,verifyGoogleToken } = require('../utils/crypto');
 
 const router = express.Router();
 router.use(cookieParser());
+router.use(lusca.csrf());
 // Route d'inscription
 router.post('/register', async (req, res) => {
     const username = req.body.username;


### PR DESCRIPTION
Potential fix for [https://github.com/visualAngus/NeosMentis2.0/security/code-scanning/22](https://github.com/visualAngus/NeosMentis2.0/security/code-scanning/22)

To fix the problem, we need to add CSRF protection middleware to the Express application. The `lusca` package is a well-known middleware for this purpose. We will:
1. Install the `lusca` package.
2. Import the `lusca` package in the `routes/auth.js` file.
3. Use the `lusca.csrf()` middleware in the router to protect against CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
